### PR TITLE
chore: preserve semver ranges in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,7 @@
     ":enableVulnerabilityAlertsWithLabel(security)", // https://docs.renovatebot.com/presets-default/#enablevulnerabilityalertswithlabelarg0
     "group:recommended", // https://docs.renovatebot.com/presets-group/#grouprecommended
     "workarounds:all", // https://docs.renovatebot.com/presets-workarounds/#workaroundsall
+    ":preserveSemverRanges", // https://docs.renovatebot.com/presets-default/#preservesemverranges
   ],
   "reviewersFromCodeOwners": true,
   "dependencyDashboard": true,


### PR DESCRIPTION
## Motivation

Keep Renovate from rewriting version constraints when updating dependencies.
This preserves the repository's intended dependency range policy.

Otherwise, this is what happens:
<img width="836" height="387" alt="image" src="https://github.com/user-attachments/assets/ad1d4f0d-cfa4-41b8-a015-d0077565277d" />

I don't believe there's much gain in pinning specific versions. If I wanted to be super secure, I'd have to pin commits.