### PR TITLE
feat: add GitHub release secret setup to bootstrap CLI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install devbox
         uses: jetpack-io/devbox-install-action@v0.15.0
         with:

--- a/.github/workflows/pr-autolabeler.yml
+++ b/.github/workflows/pr-autolabeler.yml
@@ -14,6 +14,6 @@ jobs:
   autolabeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter/autolabeler@v7.3.1
+      - uses: release-drafter/release-drafter/autolabeler@v7.5.1
         with:
           token: ${{ github.token }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -33,7 +33,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.RELEASE_DRAFTER_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
       - name: Add release notes to the draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Go

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install devbox
         uses: jetpack-io/devbox-install-action@v0.15.0
         with:

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ The CLI will guide you through an interactive form to configure your new project
 - **GitHub Account Name**: The GitHub account or organization that owns this repository
 - **Repository Name**: The name of your new repository
 - **Include Binary Support?**:
-  Whether to include goreleaser configuration and binary build workflows
+  Whether to include GoReleaser configuration and binary build workflows
 - **Include Versioning Support?**:
   Whether to include release drafter and automated versioning workflows
+- **Set GitHub Release Secrets?**:
+  Optionally store a supplied personal access token as the required GitHub
+  Actions release secrets with the GitHub CLI.
 
 ## Devbox
 
@@ -77,17 +80,32 @@ if the paths you're interested in are covered with `just test-coverage`.
 ## Releasing binaries
 
 If you decide to ship binaries with the project,
-[Goreleaser](https://goreleaser.com/) will require setting up
+[GoReleaser](https://goreleaser.com/) will require setting up
 `GORELEASER_TOKEN` secret.
-Refer to [goreleaser-action](https://github.com/goreleaser/goreleaser-action)
-docs for up-to-date permission requirements for the token.
+Use a dedicated fine-grained personal access token scoped to the generated
+repository with `Contents: read and write`.
+`Metadata: read-only` is included automatically.
 
 ## Release Drafter
 
-If you decide to keep release automation, you will need to setup
+If you decide to keep release automation, you will need to set up
 `RELEASE_DRAFTER_TOKEN` secret.
-Refer to [release-drafter](https://github.com/release-drafter/release-drafter?tab=readme-ov-file#usage)
-docs for up-to-date permission requirements for the token.
+Use a dedicated fine-grained personal access token scoped to the generated
+repository with `Contents: read and write` and
+`Pull requests: read and write`.
+`Metadata: read-only` is included automatically.
+
+## GitHub release secrets
+
+The bootstrap CLI does not create personal access tokens.
+For the least-privilege setup, create separate tokens for GoReleaser and
+Release Drafter with the permissions listed above.
+Store them with [GitHub CLI](https://cli.github.com/):
+
+```shell
+gh secret set GORELEASER_TOKEN --repo <github-account-name>/<repo-name>
+gh secret set RELEASE_DRAFTER_TOKEN --repo <github-account-name>/<repo-name>
+```
 
 ## Labels
 

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -7,10 +7,21 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/huh"
+)
+
+const (
+	goreleaserSecretName     = "GORELEASER_TOKEN"
+	releaseDrafterSecretName = "RELEASE_DRAFTER_TOKEN"
+)
+
+var (
+	findExecutable   = exec.LookPath
+	runGitHubCommand = runExternalCommand
 )
 
 type config struct {
@@ -18,6 +29,8 @@ type config struct {
 	repoName       string
 	includeBinary  bool
 	includeVersion bool
+	setupSecrets   bool
+	releaseToken   string
 }
 
 func main() {
@@ -37,7 +50,14 @@ func run() error {
 	fmt.Printf("  Account: %s\n", cfg.accountName)
 	fmt.Printf("  Repository: %s\n", cfg.repoName)
 	fmt.Printf("  Binary support: %v\n", cfg.includeBinary)
-	fmt.Printf("  Versioning support: %v\n\n", cfg.includeVersion)
+	fmt.Printf("  Versioning support: %v\n", cfg.includeVersion)
+	fmt.Printf("  Secret setup: %v\n\n", cfg.setupSecrets)
+
+	if cfg.setupSecrets {
+		if err := setupReleaseSecrets(cfg); err != nil {
+			return fmt.Errorf("failed to setup release secrets: %w", err)
+		}
+	}
 
 	if err := bootstrap(cfg); err != nil {
 		return fmt.Errorf("bootstrap failed: %w", err)
@@ -72,11 +92,18 @@ func loadConfigFromEnv(accountName string) (*config, error) {
 	if err := validateName(repoName, "BOOTSTRAP_REPO"); err != nil {
 		return nil, err
 	}
+	setupSecrets := os.Getenv("BOOTSTRAP_SETUP_SECRETS") == "true"
+	releaseToken := strings.TrimSpace(os.Getenv("BOOTSTRAP_RELEASE_TOKEN"))
+	if setupSecrets && releaseToken == "" {
+		return nil, errors.New("BOOTSTRAP_RELEASE_TOKEN environment variable is required when BOOTSTRAP_SETUP_SECRETS=true")
+	}
 	return &config{
 		accountName:    accountName,
 		repoName:       repoName,
 		includeBinary:  os.Getenv("BOOTSTRAP_NO_BINARY") != "true",
 		includeVersion: os.Getenv("BOOTSTRAP_NO_VERSIONING") != "true",
+		setupSecrets:   setupSecrets,
+		releaseToken:   releaseToken,
 	}, nil
 }
 
@@ -105,10 +132,31 @@ func loadConfigInteractive(in io.Reader, out io.Writer) (*config, error) {
 		Title("Include Versioning Support?").
 		Description("Include release drafter and automated versioning workflows").
 		Value(&cfg.includeVersion)
+	setupSecretsConfirm := huh.NewConfirm().
+		Title("Set GitHub Release Secrets?").
+		Description("Store the supplied release token as the required GitHub Actions secrets").
+		Value(&cfg.setupSecrets)
+	tokenInput := huh.NewInput().
+		Title("GitHub Release Token").
+		Description("Personal access token for release automation; input is hidden").
+		EchoMode(huh.EchoModePassword).
+		Value(&cfg.releaseToken).
+		Validate(func(s string) error {
+			if strings.TrimSpace(s) == "" {
+				return errors.New("GitHub release token cannot be empty")
+			}
+			return nil
+		})
 
 	form := huh.NewForm(
 		huh.NewGroup(accountInput, repoInput),
 		huh.NewGroup(binaryConfirm, versionConfirm),
+		huh.NewGroup(setupSecretsConfirm).WithHideFunc(func() bool {
+			return !cfg.includeBinary && !cfg.includeVersion
+		}),
+		huh.NewGroup(tokenInput).WithHideFunc(func() bool {
+			return !cfg.setupSecrets
+		}),
 	).
 		WithInput(in).
 		WithOutput(out).
@@ -118,6 +166,10 @@ func loadConfigInteractive(in io.Reader, out io.Writer) (*config, error) {
 	}
 	cfg.accountName = strings.TrimSpace(cfg.accountName)
 	cfg.repoName = strings.TrimSpace(cfg.repoName)
+	if cfg.setupSecrets {
+		cfg.releaseToken = strings.TrimSpace(cfg.releaseToken)
+	}
+
 	return cfg, nil
 }
 
@@ -177,6 +229,48 @@ func bootstrap(cfg *config) error {
 	}
 
 	return nil
+}
+
+func setupReleaseSecrets(cfg *config) error {
+	repo := cfg.accountName + "/" + cfg.repoName
+	if _, err := findExecutable("gh"); err != nil {
+		return fmt.Errorf("GitHub CLI (gh) is required to set release secrets: %w", err)
+	}
+	if output, err := runGitHubCommand("", "gh", "auth", "status"); err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail != "" {
+			return fmt.Errorf("gh auth status failed: %w: %s", err, detail)
+		}
+		return fmt.Errorf("gh auth status failed: %w", err)
+	}
+
+	if cfg.includeBinary {
+		if err := setGitHubSecret(repo, goreleaserSecretName, cfg.releaseToken); err != nil {
+			return err
+		}
+	}
+	if cfg.includeVersion {
+		if err := setGitHubSecret(repo, releaseDrafterSecretName, cfg.releaseToken); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setGitHubSecret(repo, secretName, token string) error {
+	if _, err := runGitHubCommand(token, "gh", "secret", "set", secretName, "--repo", repo); err != nil {
+		return fmt.Errorf("gh secret set failed for %s in %s: %w", secretName, repo, err)
+	}
+	fmt.Printf("  Set %s for %s\n", secretName, repo)
+	return nil
+}
+
+func runExternalCommand(stdin string, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	return cmd.CombinedOutput()
 }
 
 func removeBinarySupport() error {

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -21,6 +21,7 @@ const (
 
 var (
 	findExecutable   = exec.LookPath
+	runGitCommand    = runExternalCommand
 	runGitHubCommand = runExternalCommand
 )
 
@@ -109,6 +110,10 @@ func loadConfigFromEnv(accountName string) (*config, error) {
 
 func loadConfigInteractive(in io.Reader, out io.Writer) (*config, error) {
 	cfg := &config{}
+	if accountName, repoName := detectRepositoryIdentity(); accountName != "" && repoName != "" {
+		cfg.accountName = accountName
+		cfg.repoName = repoName
+	}
 
 	accountInput := huh.NewInput().
 		Title("GitHub Account Name").
@@ -171,6 +176,59 @@ func loadConfigInteractive(in io.Reader, out io.Writer) (*config, error) {
 	}
 
 	return cfg, nil
+}
+
+func detectRepositoryIdentity() (string, string) {
+	if output, err := runGitCommand("", "git", "remote", "get-url", "origin"); err == nil {
+		if accountName, repoName := parseGitHubRepository(strings.TrimSpace(string(output))); accountName != "" && repoName != "" {
+			return accountName, repoName
+		}
+	}
+
+	if output, err := runGitHubCommand(
+		"",
+		"gh",
+		"repo",
+		"view",
+		"--json",
+		"owner,name",
+		"--jq",
+		".owner.login + \"/\" + .name",
+	); err == nil {
+		if accountName, repoName := splitRepositoryName(strings.TrimSpace(string(output))); accountName != "" && repoName != "" {
+			return accountName, repoName
+		}
+	}
+
+	return "", ""
+}
+
+func parseGitHubRepository(remoteURL string) (string, string) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	remoteURL = strings.TrimSuffix(remoteURL, ".git")
+
+	switch {
+	case strings.HasPrefix(remoteURL, "git@github.com:"):
+		return splitRepositoryName(strings.TrimPrefix(remoteURL, "git@github.com:"))
+	case strings.HasPrefix(remoteURL, "https://github.com/"):
+		return splitRepositoryName(strings.TrimPrefix(remoteURL, "https://github.com/"))
+	case strings.HasPrefix(remoteURL, "http://github.com/"):
+		return splitRepositoryName(strings.TrimPrefix(remoteURL, "http://github.com/"))
+	case strings.HasPrefix(remoteURL, "ssh://git@github.com/"):
+		return splitRepositoryName(strings.TrimPrefix(remoteURL, "ssh://git@github.com/"))
+	case strings.HasPrefix(remoteURL, "github.com/"):
+		return splitRepositoryName(strings.TrimPrefix(remoteURL, "github.com/"))
+	default:
+		return "", ""
+	}
+}
+
+func splitRepositoryName(repository string) (string, string) {
+	parts := strings.Split(strings.Trim(repository, "/"), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", ""
+	}
+	return parts[0], parts[1]
 }
 
 func validateName(name, field string) error {

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -155,7 +155,8 @@ func loadConfigInteractive(in io.Reader, out io.Writer) (*config, error) {
 
 	form := huh.NewForm(
 		huh.NewGroup(accountInput, repoInput),
-		huh.NewGroup(binaryConfirm, versionConfirm),
+		huh.NewGroup(binaryConfirm),
+		huh.NewGroup(versionConfirm),
 		huh.NewGroup(setupSecretsConfirm).WithHideFunc(func() bool {
 			return !cfg.includeBinary && !cfg.includeVersion
 		}),

--- a/bootstrap/main_test.go
+++ b/bootstrap/main_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	_ "embed"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -223,6 +225,7 @@ func TestLoadConfigInteractive_BothEnabled(t *testing.T) {
 	assert.Equal(t, "my-repo", cfg.repoName)
 	assert.True(t, cfg.includeBinary)
 	assert.True(t, cfg.includeVersion)
+	assert.False(t, cfg.setupSecrets)
 }
 
 func TestLoadConfigInteractive_BinaryDisabled(t *testing.T) {
@@ -252,6 +255,7 @@ func TestLoadConfigInteractive_WhitespaceTrimmed(t *testing.T) {
 		AddResponse("Repository Name", "  my-repo  ").
 		AddConfirm("Include Binary Support?", huhtest.ConfirmAffirm).
 		AddConfirm("Include Versioning Support?", huhtest.ConfirmAffirm).
+		AddConfirm("Set GitHub Release Secrets?", huhtest.ConfirmNegative).
 		Start(t, 30*time.Second)
 	defer cancel()
 
@@ -261,6 +265,30 @@ func TestLoadConfigInteractive_WhitespaceTrimmed(t *testing.T) {
 	assert.Equal(t, "my-repo", cfg.repoName)
 }
 
+func TestLoadConfigInteractive_SetupSecrets(t *testing.T) {
+	stdin, stdout, cancel := huhtest.NewResponder().
+		AddResponse("GitHub Account Name", "my-account").
+		AddResponse("Repository Name", "my-repo").
+		AddConfirm("Include Binary Support?", huhtest.ConfirmAffirm).
+		AddConfirm("Include Versioning Support?", huhtest.ConfirmAffirm).
+		AddConfirm("Set GitHub Release Secrets?", huhtest.ConfirmAffirm).
+		AddResponse("GitHub Release Token", "  secret-token  ").
+		Start(t, 30*time.Second)
+	defer cancel()
+
+	cfg, err := loadConfigInteractive(stdin, stdout)
+	require.NoError(t, err)
+	assert.True(t, cfg.setupSecrets)
+	assert.Equal(t, "secret-token", cfg.releaseToken)
+}
+
+func TestLoadConfigInteractive_SkipsSecretsPromptWithoutReleaseFeatures(t *testing.T) {
+	cfg, err := runLoadConfigInteractive(t, false, false)
+	require.NoError(t, err)
+	assert.False(t, cfg.setupSecrets)
+	assert.Empty(t, cfg.releaseToken)
+}
+
 func TestLoadConfigFromEnv(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -268,11 +296,15 @@ func TestLoadConfigFromEnv(t *testing.T) {
 		repo           string
 		noBinary       string
 		noVersioning   string
+		setupSecrets   string
+		releaseToken   string
 		wantErr        bool
 		wantAccount    string
 		wantRepo       string
 		wantBinary     bool
 		wantVersioning bool
+		wantSetup      bool
+		wantToken      string
 	}{
 		{
 			name:    "missing BOOTSTRAP_REPO returns error",
@@ -339,6 +371,26 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			wantBinary:     true,
 			wantVersioning: true,
 		},
+		{
+			name:           "BOOTSTRAP_SETUP_SECRETS=true stores trimmed token",
+			account:        "my-account",
+			repo:           "my-repo",
+			setupSecrets:   "true",
+			releaseToken:   "  secret-token  ",
+			wantAccount:    "my-account",
+			wantRepo:       "my-repo",
+			wantBinary:     true,
+			wantVersioning: true,
+			wantSetup:      true,
+			wantToken:      "secret-token",
+		},
+		{
+			name:         "BOOTSTRAP_SETUP_SECRETS=true requires token",
+			account:      "my-account",
+			repo:         "my-repo",
+			setupSecrets: "true",
+			wantErr:      true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -347,6 +399,8 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			t.Setenv("BOOTSTRAP_REPO", tt.repo)
 			t.Setenv("BOOTSTRAP_NO_BINARY", tt.noBinary)
 			t.Setenv("BOOTSTRAP_NO_VERSIONING", tt.noVersioning)
+			t.Setenv("BOOTSTRAP_SETUP_SECRETS", tt.setupSecrets)
+			t.Setenv("BOOTSTRAP_RELEASE_TOKEN", tt.releaseToken)
 
 			cfg, err := loadConfigFromEnv(tt.account)
 			if tt.wantErr {
@@ -358,6 +412,139 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			assert.Equal(t, tt.wantRepo, cfg.repoName)
 			assert.Equal(t, tt.wantBinary, cfg.includeBinary)
 			assert.Equal(t, tt.wantVersioning, cfg.includeVersion)
+			assert.Equal(t, tt.wantSetup, cfg.setupSecrets)
+			assert.Equal(t, tt.wantToken, cfg.releaseToken)
+		})
+	}
+}
+
+func TestSetupReleaseSecrets(t *testing.T) {
+	tests := map[string]struct {
+		cfg          *config
+		lookPathErr  error
+		commandErrs  map[string]error
+		wantCommands [][]string
+		wantStdin    []string
+		wantErr      string
+	}{
+		"binary only": {
+			cfg: &config{
+				accountName:   "my-account",
+				repoName:      "my-repo",
+				includeBinary: true,
+				releaseToken:  "secret-token",
+			},
+			wantCommands: [][]string{
+				{"gh", "auth", "status"},
+				{"gh", "secret", "set", goreleaserSecretName, "--repo", "my-account/my-repo"},
+			},
+			wantStdin: []string{"", "secret-token"},
+		},
+		"versioning only": {
+			cfg: &config{
+				accountName:    "my-account",
+				repoName:       "my-repo",
+				includeVersion: true,
+				releaseToken:   "secret-token",
+			},
+			wantCommands: [][]string{
+				{"gh", "auth", "status"},
+				{"gh", "secret", "set", releaseDrafterSecretName, "--repo", "my-account/my-repo"},
+			},
+			wantStdin: []string{"", "secret-token"},
+		},
+		"both release features": {
+			cfg: &config{
+				accountName:    "my-account",
+				repoName:       "my-repo",
+				includeBinary:  true,
+				includeVersion: true,
+				releaseToken:   "secret-token",
+			},
+			wantCommands: [][]string{
+				{"gh", "auth", "status"},
+				{"gh", "secret", "set", goreleaserSecretName, "--repo", "my-account/my-repo"},
+				{"gh", "secret", "set", releaseDrafterSecretName, "--repo", "my-account/my-repo"},
+			},
+			wantStdin: []string{"", "secret-token", "secret-token"},
+		},
+		"missing gh": {
+			cfg: &config{
+				accountName:   "my-account",
+				repoName:      "my-repo",
+				includeBinary: true,
+				releaseToken:  "secret-token",
+			},
+			lookPathErr: errors.New("executable file not found"),
+			wantErr:     "GitHub CLI (gh) is required",
+		},
+		"auth failure": {
+			cfg: &config{
+				accountName:   "my-account",
+				repoName:      "my-repo",
+				includeBinary: true,
+				releaseToken:  "secret-token",
+			},
+			commandErrs: map[string]error{
+				"gh auth status": errors.New("exit status 1"),
+			},
+			wantCommands: [][]string{
+				{"gh", "auth", "status"},
+			},
+			wantStdin: []string{""},
+			wantErr:   "gh auth status failed",
+		},
+		"secret set failure": {
+			cfg: &config{
+				accountName:   "my-account",
+				repoName:      "my-repo",
+				includeBinary: true,
+				releaseToken:  "secret-token",
+			},
+			commandErrs: map[string]error{
+				"gh secret set GORELEASER_TOKEN --repo my-account/my-repo": errors.New("exit status 1"),
+			},
+			wantCommands: [][]string{
+				{"gh", "auth", "status"},
+				{"gh", "secret", "set", goreleaserSecretName, "--repo", "my-account/my-repo"},
+			},
+			wantStdin: []string{"", "secret-token"},
+			wantErr:   "gh secret set failed for GORELEASER_TOKEN",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var commands [][]string
+			var stdins []string
+			restoreCommandHooks(t)
+			findExecutable = func(file string) (string, error) {
+				assert.Equal(t, "gh", file)
+				if tt.lookPathErr != nil {
+					return "", tt.lookPathErr
+				}
+				return "/usr/bin/gh", nil
+			}
+			runGitHubCommand = func(stdin string, name string, args ...string) ([]byte, error) {
+				command := append([]string{name}, args...)
+				commands = append(commands, command)
+				stdins = append(stdins, stdin)
+				if err := tt.commandErrs[strings.Join(command, " ")]; err != nil {
+					return []byte("command failed"), err
+				}
+				return []byte("ok"), nil
+			}
+
+			err := setupReleaseSecrets(tt.cfg)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.NotContains(t, err.Error(), "secret-token")
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCommands, commands)
+			assert.Equal(t, tt.wantStdin, stdins)
 		})
 	}
 }
@@ -369,6 +556,17 @@ func getExpectedJustfile(t *testing.T, includeBinary bool) string {
 		return expectedJustfileWithBinary
 	}
 	return expectedJustfileNoBinary
+}
+
+func restoreCommandHooks(t *testing.T) {
+	t.Helper()
+
+	originalFindExecutable := findExecutable
+	originalRunGitHubCommand := runGitHubCommand
+	t.Cleanup(func() {
+		findExecutable = originalFindExecutable
+		runGitHubCommand = originalRunGitHubCommand
+	})
 }
 
 func runBootstrap(t *testing.T, tmpDir string, args ...string) (string, error) {
@@ -446,12 +644,16 @@ func runLoadConfigInteractive(t *testing.T, includeBinary, includeVersion bool) 
 		includeVersionResponse = huhtest.ConfirmAffirm
 	}
 
-	stdin, stdout, cancel := huhtest.NewResponder().
+	responder := huhtest.NewResponder().
 		AddResponse("GitHub Account Name", "my-account").
 		AddResponse("Repository Name", "my-repo").
 		AddConfirm("Include Binary Support?", includeBinaryResponse).
-		AddConfirm("Include Versioning Support?", includeVersionResponse).
-		Start(t, 30*time.Second)
+		AddConfirm("Include Versioning Support?", includeVersionResponse)
+	if includeBinary || includeVersion {
+		responder = responder.AddConfirm("Set GitHub Release Secrets?", huhtest.ConfirmNegative)
+	}
+
+	stdin, stdout, cancel := responder.Start(t, 30*time.Second)
 	defer cancel()
 
 	return loadConfigInteractive(stdin, stdout)

--- a/bootstrap/main_test.go
+++ b/bootstrap/main_test.go
@@ -250,6 +250,8 @@ func TestLoadConfigInteractive_BothDisabled(t *testing.T) {
 }
 
 func TestLoadConfigInteractive_WhitespaceTrimmed(t *testing.T) {
+	disableRepositoryDetection(t)
+
 	stdin, stdout, cancel := huhtest.NewResponder().
 		AddResponse("GitHub Account Name", "  my-account  ").
 		AddResponse("Repository Name", "  my-repo  ").
@@ -266,6 +268,8 @@ func TestLoadConfigInteractive_WhitespaceTrimmed(t *testing.T) {
 }
 
 func TestLoadConfigInteractive_SetupSecrets(t *testing.T) {
+	disableRepositoryDetection(t)
+
 	stdin, stdout, cancel := huhtest.NewResponder().
 		AddResponse("GitHub Account Name", "my-account").
 		AddResponse("Repository Name", "my-repo").
@@ -418,6 +422,115 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	}
 }
 
+func TestDetectRepositoryIdentity(t *testing.T) {
+	tests := map[string]struct {
+		gitOutput          string
+		gitErr             error
+		ghOutput           string
+		ghErr              error
+		wantAccount        string
+		wantRepo           string
+		wantGitCommands    [][]string
+		wantGitHubCommands [][]string
+	}{
+		"git remote": {
+			gitOutput:       "https://github.com/my-account/my-repo.git\n",
+			wantAccount:     "my-account",
+			wantRepo:        "my-repo",
+			wantGitCommands: [][]string{{"git", "remote", "get-url", "origin"}},
+		},
+		"gh fallback": {
+			gitErr:             errors.New("exit status 2"),
+			ghOutput:           "my-account/my-repo\n",
+			wantAccount:        "my-account",
+			wantRepo:           "my-repo",
+			wantGitCommands:    [][]string{{"git", "remote", "get-url", "origin"}},
+			wantGitHubCommands: [][]string{{"gh", "repo", "view", "--json", "owner,name", "--jq", ".owner.login + \"/\" + .name"}},
+		},
+		"no repository detected": {
+			gitErr:             errors.New("exit status 2"),
+			ghErr:              errors.New("exit status 1"),
+			wantGitCommands:    [][]string{{"git", "remote", "get-url", "origin"}},
+			wantGitHubCommands: [][]string{{"gh", "repo", "view", "--json", "owner,name", "--jq", ".owner.login + \"/\" + .name"}},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var gitCommands [][]string
+			var gitHubCommands [][]string
+			restoreCommandHooks(t)
+			runGitCommand = func(stdin string, name string, args ...string) ([]byte, error) {
+				assert.Empty(t, stdin)
+				command := append([]string{name}, args...)
+				gitCommands = append(gitCommands, command)
+				return []byte(tt.gitOutput), tt.gitErr
+			}
+			runGitHubCommand = func(stdin string, name string, args ...string) ([]byte, error) {
+				assert.Empty(t, stdin)
+				command := append([]string{name}, args...)
+				gitHubCommands = append(gitHubCommands, command)
+				return []byte(tt.ghOutput), tt.ghErr
+			}
+
+			accountName, repoName := detectRepositoryIdentity()
+
+			assert.Equal(t, tt.wantAccount, accountName)
+			assert.Equal(t, tt.wantRepo, repoName)
+			assert.Equal(t, tt.wantGitCommands, gitCommands)
+			assert.Equal(t, tt.wantGitHubCommands, gitHubCommands)
+		})
+	}
+}
+
+func TestParseGitHubRepository(t *testing.T) {
+	tests := map[string]struct {
+		remoteURL   string
+		wantAccount string
+		wantRepo    string
+	}{
+		"https remote": {
+			remoteURL:   "https://github.com/my-account/my-repo.git",
+			wantAccount: "my-account",
+			wantRepo:    "my-repo",
+		},
+		"http remote": {
+			remoteURL:   "http://github.com/my-account/my-repo.git",
+			wantAccount: "my-account",
+			wantRepo:    "my-repo",
+		},
+		"scp-like ssh remote": {
+			remoteURL:   "git@github.com:my-account/my-repo.git",
+			wantAccount: "my-account",
+			wantRepo:    "my-repo",
+		},
+		"ssh URL remote": {
+			remoteURL:   "ssh://git@github.com/my-account/my-repo.git",
+			wantAccount: "my-account",
+			wantRepo:    "my-repo",
+		},
+		"host path remote": {
+			remoteURL:   "github.com/my-account/my-repo",
+			wantAccount: "my-account",
+			wantRepo:    "my-repo",
+		},
+		"non-GitHub remote": {
+			remoteURL: "git@example.com:my-account/my-repo.git",
+		},
+		"nested path": {
+			remoteURL: "https://github.com/my-account/my-repo/extra.git",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			accountName, repoName := parseGitHubRepository(tt.remoteURL)
+			assert.Equal(t, tt.wantAccount, accountName)
+			assert.Equal(t, tt.wantRepo, repoName)
+		})
+	}
+}
+
 func TestSetupReleaseSecrets(t *testing.T) {
 	tests := map[string]struct {
 		cfg          *config
@@ -562,11 +675,25 @@ func restoreCommandHooks(t *testing.T) {
 	t.Helper()
 
 	originalFindExecutable := findExecutable
+	originalRunGitCommand := runGitCommand
 	originalRunGitHubCommand := runGitHubCommand
 	t.Cleanup(func() {
 		findExecutable = originalFindExecutable
+		runGitCommand = originalRunGitCommand
 		runGitHubCommand = originalRunGitHubCommand
 	})
+}
+
+func disableRepositoryDetection(t *testing.T) {
+	t.Helper()
+
+	restoreCommandHooks(t)
+	runGitCommand = func(string, string, ...string) ([]byte, error) {
+		return nil, errors.New("git repository detection disabled")
+	}
+	runGitHubCommand = func(string, string, ...string) ([]byte, error) {
+		return nil, errors.New("GitHub repository detection disabled")
+	}
 }
 
 func runBootstrap(t *testing.T, tmpDir string, args ...string) (string, error) {
@@ -634,6 +761,7 @@ func readFile(t *testing.T, path string) string {
 
 func runLoadConfigInteractive(t *testing.T, includeBinary, includeVersion bool) (*config, error) {
 	t.Helper()
+	disableRepositoryDetection(t)
 
 	includeBinaryResponse := huhtest.ConfirmNegative
 	if includeBinary {


### PR DESCRIPTION
## Motivation

In order to speed up the process of creating repositories from this template we could create the required secrets. 

## Summary

Allow bootstrap to optionally store release automation tokens with `gh secret set` for generated repositories when binary or versioning support is enabled.
