### PR TITLE
chore: split release drafter autolabeling

### DIFF
--- a/.github/workflows/pr-autolabeler.yml
+++ b/.github/workflows/pr-autolabeler.yml
@@ -1,0 +1,19 @@
+name: PR Autolabeler
+
+on:
+  # pull_request_target is required to label PRs from forks.
+  # This workflow must stay metadata-only: do not checkout or run PR code here.
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autolabeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7.3.1
+        with:
+          token: ${{ github.token }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,28 +4,12 @@ on:
   push:
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  # 'edited' event is required to account for initial invalid PR names
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read
 
 jobs:
-  autolabeler:
-    if: github.event_name == 'pull_request'
-    permissions:
-      # write permission is required to add labels to pull requests
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: release-drafter/release-drafter/autolabeler@v7
-        with:
-          token: ${{ secrets.RELEASE_DRAFTER_TOKEN }}
-
   update_release_draft:
-    if: github.event_name == 'push'
     permissions:
       # write permission is required to create a github release
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
       - name: Release Binaries
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           version: latest
           args: release --clean

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -332,6 +332,7 @@ func removeVersioningSupport() error {
 	filesToRemove := []string{
 		".github/scripts/release-notes.bash",
 		".github/release-drafter.yml",
+		".github/workflows/pr-autolabeler.yml",
 		".github/workflows/release-drafter.yml",
 	}
 

--- a/bootstrap/main_test.go
+++ b/bootstrap/main_test.go
@@ -78,6 +78,7 @@ func TestBootstrap_DefaultBehavior(t *testing.T) {
 	t.Run("keeps versioning-related files", func(t *testing.T) {
 		assert.FileExists(t, filepath.Join(tmpDir, ".github", "scripts", "release-notes.bash"))
 		assert.FileExists(t, filepath.Join(tmpDir, ".github", "release-drafter.yml"))
+		assert.FileExists(t, filepath.Join(tmpDir, ".github", "workflows", "pr-autolabeler.yml"))
 		assert.FileExists(t, filepath.Join(tmpDir, ".github", "workflows", "release-drafter.yml"))
 	})
 
@@ -131,6 +132,7 @@ func TestBootstrap_NoVersioningFlag(t *testing.T) {
 	t.Run("removes versioning-related files", func(t *testing.T) {
 		assert.NoFileExists(t, filepath.Join(tmpDir, ".github", "scripts", "release-notes.bash"))
 		assert.NoFileExists(t, filepath.Join(tmpDir, ".github", "release-drafter.yml"))
+		assert.NoFileExists(t, filepath.Join(tmpDir, ".github", "workflows", "pr-autolabeler.yml"))
 		assert.NoFileExists(t, filepath.Join(tmpDir, ".github", "workflows", "release-drafter.yml"))
 	})
 	t.Run("keeps binary-related files", func(t *testing.T) {
@@ -432,7 +434,7 @@ func readFile(t *testing.T, path string) string {
 	return string(content)
 }
 
-func runLoadConfigInteractive(t *testing.T, includeBinary bool, includeVersion bool) (*config, error) {
+func runLoadConfigInteractive(t *testing.T, includeBinary, includeVersion bool) (*config, error) {
 	t.Helper()
 
 	includeBinaryResponse := huhtest.ConfirmNegative


### PR DESCRIPTION
## Motivation

Port the applicable release workflow improvements from `nobl9/sloctl` so PR labeling is handled separately from release drafting and can label forked PRs without requiring a custom release-drafter secret.

## Summary

- Add a metadata-only `pull_request_target` PR autolabeler workflow using `github.token`.
- Keep release drafter focused on updating release drafts from `main` pushes.
- Pin the Goreleaser action to `v7.2.2`.
- Keep bootstrap versioning cleanup in sync with the new autolabeler workflow.
