### PR TITLE
infra: replace PR title action with inline check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,10 +10,27 @@ jobs:
   pr-title-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: Slashgear/action-check-pr-title@v5.0.1
-        with:
-          regexp: "^(feat|fix|sec|infra|test|chore|doc): .{5,}"
-          helpMessage: "Example: 'feat: new pr title check' <- prefix, colon, space, PR title of at least 5 chars"
+      - name: Check PR title
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+        run: |
+          set -euo pipefail
+
+          readonly PR_TITLE_PATTERN='^(feat|fix|sec|infra|test|chore|doc): .{5,}$'
+
+          if [[ -z "${PR_TITLE}" ]]; then
+            echo "Skipping PR title check: this event does not include a pull request title."
+            exit 0
+          fi
+
+          if [[ "${PR_TITLE}" =~ ${PR_TITLE_PATTERN} ]]; then
+            exit 0
+          fi
+
+          echo "Pull request title must match: ${PR_TITLE_PATTERN}" >&2
+          echo "Example: 'feat: new pr title check'" >&2
+          exit 1
 
   release-notes-check:
     if: github.event_name == 'pull_request'

--- a/bootstrap/main_test.go
+++ b/bootstrap/main_test.go
@@ -86,6 +86,9 @@ func TestBootstrap_DefaultBehavior(t *testing.T) {
 
 		prCheck := readFile(t, filepath.Join(tmpDir, ".github", "workflows", "pr-check.yml"))
 		assert.Contains(t, prCheck, "  pr-title-check:")
+		assert.Contains(t, prCheck, "name: Check PR title")
+		assert.Contains(t, prCheck, "readonly PR_TITLE_PATTERN='^(feat|fix|sec|infra|test|chore|doc): .{5,}$'")
+		assert.NotContains(t, prCheck, "Slashgear/action-check-pr-title")
 		assert.Contains(t, prCheck, "  release-notes-check:")
 	})
 
@@ -146,6 +149,9 @@ func TestBootstrap_NoVersioningFlag(t *testing.T) {
 		prCheck := readFile(t, filepath.Join(tmpDir, ".github", "workflows", "pr-check.yml"))
 
 		assert.Contains(t, prCheck, "  pr-title-check:")
+		assert.Contains(t, prCheck, "name: Check PR title")
+		assert.Contains(t, prCheck, "readonly PR_TITLE_PATTERN='^(feat|fix|sec|infra|test|chore|doc): .{5,}$'")
+		assert.NotContains(t, prCheck, "Slashgear/action-check-pr-title")
 		assert.NotContains(t, prCheck, "  release-notes-check:")
 	})
 	t.Run("keeps binary-related files", func(t *testing.T) {


### PR DESCRIPTION
## Motivation

`improve-pr-release-automation` was only partially represented on `main`; the combined PR check workflow still used `Slashgear/action-check-pr-title@v5.0.1` even though the follow-up branch removed that dependency.

## Summary

- Replaced the third-party PR title action with an inline Bash validation in the PR check workflow.
- Added bootstrap assertions so generated repositories keep the inline check and do not reintroduce the Slashgear action.

## Related Changes

Backfilled missing commit `92a4d5c` from `improve-pr-release-automation`.
